### PR TITLE
[CMS PR 42799] Use client_id instead of client

### DIFF
--- a/libraries/src/Updater/Adapter/TufAdapter.php
+++ b/libraries/src/Updater/Adapter/TufAdapter.php
@@ -180,7 +180,7 @@ class TufAdapter extends UpdateAdapter
                 'type'                => null,
                 'client'              => 'site',
                 'client_id'           => 0,
-                'version'             => "1",
+                'version'             => '1',
                 'data'                => '',
                 'detailsurl'          => '',
                 'infourl'             => '',

--- a/libraries/src/Updater/Adapter/TufAdapter.php
+++ b/libraries/src/Updater/Adapter/TufAdapter.php
@@ -144,7 +144,7 @@ class TufAdapter extends UpdateAdapter
             $client = ApplicationHelper::getClientInfo($values['client'], true);
 
             if (\is_object($client)) {
-                $values['client'] = $client->id;
+                $values['client_id'] = $client->id;
             }
         }
 
@@ -178,7 +178,8 @@ class TufAdapter extends UpdateAdapter
                 'description'         => '',
                 'element'             => '',
                 'type'                => null,
-                'client'              => 0,
+                'client'              => 'site',
+                'client_id'           => 0,
                 'version'             => "1",
                 'data'                => '',
                 'detailsurl'          => '',
@@ -199,7 +200,8 @@ class TufAdapter extends UpdateAdapter
             ->setAllowedTypes('type', 'string')
             ->setAllowedTypes('detailsurl', 'string')
             ->setAllowedTypes('infourl', 'string')
-            ->setAllowedTypes('client', 'int')
+            ->setAllowedTypes('client', 'string')
+            ->setAllowedTypes('client_id', 'int')
             ->setAllowedTypes('downloads', 'array')
             ->setAllowedTypes('targetplatform', 'array')
             ->setAllowedTypes('php_minimum', 'string')


### PR DESCRIPTION
This fixes the issue I have with PostgreSQL (and maybe also MySQL or MariaDB depending on PDO usage or strict mode or DB version).

See here the details on the issue: https://github.com/joomla/joomla-cms/pull/42799#issuecomment-1962628414 .

It seems some databases or clients do an implicit cast of an empty string to zero for an integer column in database, and others don't.

However, I'm not sure if this is the right way to fix it.

But if it is, then maybe we should remove the `client` string from the defaults and the allowed types and unset it in the `$values` array before calling the `$resolver->resolve`?

In addition, this PR fixes code style at one place (single quotes for strings wherever possible).