### PR TITLE
[CMS PR 45697] Fix removal of fieldset when autoupdate or remove installation folder buttons are clicked

### DIFF
--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -89,7 +89,8 @@ Joomla.disableAutomatedUpdates = function () {
           Joomla.renderMessages({error:['Unknown error disabling the automated updates.']});
         }
       } else {
-        document.getElementById('automatedUpdates').remove()
+        const automatedUpdates = document.getElementById('automatedUpdates');
+        automatedUpdates.parentNode.removeChild(automatedUpdates);
       }
     },
     onError: function (xhr) {

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -117,8 +117,8 @@ Joomla.deleteJoomlaInstallationDirectory = function (redirectUrl) {
             if (document.getElementById('installAddFeatures')) {
                 document.getElementById('installAddFeatures').disabled = true;
             }
-            if (document.getElementById('automatedUpdatesDisableButton')) {
-                document.getElementById('automatedUpdatesDisableButton').disabled = true;
+            if (document.getElementById('automatedUpdates')) {
+                document.getElementById('automatedUpdates').disabled = true;
             }
             if (document.getElementById('removeInstallationFolder')) {
                 document.getElementById('removeInstallationFolder').disabled = true;
@@ -137,7 +137,11 @@ Joomla.deleteJoomlaInstallationDirectory = function (redirectUrl) {
                 customInstallation.parentNode.removeChild(customInstallation);
 
                 const automatedUpdates = document.getElementById('automatedUpdates');
-                automatedUpdates.parentNode.removeChild(automatedUpdates);
+
+                // This will only exist if it has not been removed with a previous step
+                if (automatedUpdates) {
+                    automatedUpdates.parentNode.removeChild(automatedUpdates);
+                }
 
                 const removeInstallationTab = document.getElementById('removeInstallationTab');
 


### PR DESCRIPTION
- Remove the fieldset and not only the button when the opt out for the autoupdates was successful.
- Disable the fieldset and not only the button when the remove installation folder was clicked.
- When the remove installation folder was successful, remove the autoupdate fieldset only when it has not been removed before with the successful opt out.
